### PR TITLE
[Feat] 사용자 인증 시스템 구현 (로그인/회원가입/로그아웃)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.10",
-        "lucide-react": "^0.525.0",
+        "axios": "^1.11.0",
+        "lucide-react": "^0.536.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2",
@@ -2278,6 +2279,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2340,6 +2358,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -2431,6 +2462,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2529,6 +2572,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2547,6 +2599,20 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2590,6 +2656,51 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2965,6 +3076,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2979,6 +3126,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2987,6 +3143,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -3015,6 +3208,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3036,6 +3241,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ignore": {
@@ -3508,9 +3752,15 @@
       }
     },
     "node_modules/lucide-react": {
+<<<<<<< Updated upstream
       "version": "0.525.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
       "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+=======
+      "version": "0.536.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.536.0.tgz",
+      "integrity": "sha512-2PgvNa9v+qz4Jt/ni8vPLt4jwoFybXHuubQT8fv4iCW5TjDxkbZjNZZHa485ad73NSEn/jdsEtU57eE1g+ma8A==",
+>>>>>>> Stashed changes
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3523,6 +3773,15 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/merge2": {
@@ -3547,6 +3806,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3816,6 +4096,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.10",
-    "lucide-react": "^0.525.0",
+
+    "axios": "^1.11.0",
+    "lucide-react": "^0.536.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,12 @@
-import { RouterProvider, createBrowserRouter } from 'react-router-dom';
-import RootLayout from './pages/Root';
-
-import ErrorPage from './pages/Error';
-import MainPage from './pages/MainPage';
-import GithubPage from './pages/GithubPage';
-import Greeting from './pages/Greeting';
-import CreateGroupPage from './pages/CreateGroupPage';
-
-const router = createBrowserRouter([
-    {
-        path: '/',
-        element: <RootLayout />,
-        errorElement: <ErrorPage />,
-        children: [
-            { index: true, element: <MainPage /> },
-            {
-                path: 'github',
-                element: <GithubPage />,
-            },
-            {
-                path: 'create',
-                element: <CreateGroupPage />,
-            },
-            {
-                path: 'greeting',
-                element: <Greeting />,
-            },
-        ],
-    },
-]);
+import { RouterProvider } from 'react-router-dom';
+import { AppProviders } from './providers';
+import { router } from './router';
 
 function App() {
-    return <RouterProvider router={router} />;
+    return (
+        <AppProviders>
+            <RouterProvider router={router} />
+        </AppProviders>
+    );
 }
 export default App;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Bell, User } from 'lucide-react';
 import logo from '../assets/logo.png';
+import { useAuth } from '../hooks/useAuth';
 
 // Props 타입 정의
 interface HeaderProps {
@@ -9,19 +10,17 @@ interface HeaderProps {
 }
 
 const Header: React.FC<HeaderProps> = ({ onPageChange, currentPage }) => {
+    const { isAuthenticated, logout } = useAuth();
     // TODO: 실제 로그인 상태는 나중에 인증 시스템과 연동
-    const [isLoggedIn, setIsLoggedIn] = useState(false); // 임시로 false, 테스트용으로 true로 변경 가능
+    async function handleClickLogin() {
+        window.location.href =
+            'https://mogaktae.inuappcenter.kr/oauth2/authorization/github?redirect_uri=http://localhost:5173&mode=login';
+    }
 
-    const handleLogin = () => {
-        // TODO: 실제 로그인 로직 구현
-        console.log('로그인 버튼 클릭됨');
-        setIsLoggedIn(true); // 임시로 로그인 상태 변경 (테스트용)
-    };
-
-    const handleSignup = () => {
-        // TODO: 실제 회원가입 로직 구현
-        console.log('가입하기 버튼 클릭됨');
-    };
+    async function handleSignup() {
+        window.location.href =
+            'https://mogaktae.inuappcenter.kr/oauth2/authorization/github?redirect_uri=http://localhost:5173&mode=signup';
+    }
 
     const handleNotification = () => {
         // TODO: 알림 페이지로 이동 또는 알림 드롭다운 표시
@@ -36,7 +35,7 @@ const Header: React.FC<HeaderProps> = ({ onPageChange, currentPage }) => {
     const handleLogout = () => {
         // TODO: 실제 로그아웃 로직 구현
         console.log('로그아웃됨');
-        setIsLoggedIn(false);
+        logout();
     };
 
     return (
@@ -47,7 +46,7 @@ const Header: React.FC<HeaderProps> = ({ onPageChange, currentPage }) => {
                 </div>
 
                 {/* 로그인 상태에 따른 버튼 표시 */}
-                {isLoggedIn ? (
+                {isAuthenticated ? (
                     // 로그인된 상태: 알림 + 마이페이지 버튼
                     <div className="flex items-center gap-3">
                         {/* 알림 버튼 */}
@@ -90,8 +89,9 @@ const Header: React.FC<HeaderProps> = ({ onPageChange, currentPage }) => {
 
                         {/* 로그인 버튼 */}
                         <button
-                            onClick={handleLogin}
-                            className="bg-purple text-white px-6 py-2 rounded-full font-medium hover:opacity-90 transition-all"
+
+                            onClick={handleClickLogin}
+                            className="bg-login-button text-gray px-6 py-2 rounded-full font-medium hover:opacity-90 transition-all"
                         >
                             로그인
                         </button>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+import type { AuthContextValue } from '../providers/AuthProvider';
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export default AuthContext;

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import AuthContext from '../contexts/AuthContext';
+import type { AuthContextValue } from '../providers/AuthProvider';
+
+export const useAuth = (): AuthContextValue => {
+    const context = useContext(AuthContext);
+    if (!context) {
+        throw new Error('useAuth must be used within an AuthProvider');
+    }
+    return context;
+};

--- a/src/pages/GithubLoginCallback.tsx
+++ b/src/pages/GithubLoginCallback.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import { useAuth } from '../hooks/useAuth';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+const GitHubLoginCallback = () => {
+    const { login } = useAuth();
+    const [searchParams] = useSearchParams();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const accessToken = searchParams.get('accessToken');
+        const refreshToken = searchParams.get('refreshToken');
+
+        if (accessToken && refreshToken) {
+            // URL 정리
+            navigate('/');
+
+            // 토큰 저장, 로그인 처리
+            login({ accessToken, refreshToken });
+        }
+    }, [searchParams, login, navigate]);
+    return <div>CallBack!</div>;
+};
+
+export default GitHubLoginCallback;

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -1,0 +1,62 @@
+import React, { type ReactNode } from 'react';
+import { useCallback, useReducer } from 'react';
+
+import type { AuthState, AuthTokens } from '../type/auth-types';
+import { authService } from '../services/auth-service';
+import authReducer from '../reducers/AuthReducer';
+import AuthContext from '../contexts/AuthContext';
+
+export interface AuthContextValue extends AuthState {
+    login: (tokens: AuthTokens) => Promise<void>;
+    logout: () => Promise<void>;
+    // refreshAuth: () => Promise<void>;
+    // clearError: () => void;
+}
+
+const initialState: AuthState = {
+    user: null, // 처음에는 사용자 없음
+    isAuthenticated: false, // 로그인 안됨
+    isLoading: false, // 로딩중 아님
+    error: null, // 에러 없음
+};
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+    const [state, dispatch] = useReducer(authReducer, initialState);
+
+    // 로그인 함수 (OAuth 콜백에서 호출)
+    const login = useCallback(async (tokens: AuthTokens): Promise<void> => {
+        try {
+            dispatch({ type: 'AUTH_START' });
+
+            // 토큰 저장
+            authService.setTokens(tokens);
+
+            dispatch({ type: 'AUTH_SUCCESS', payload: { id: 'hani0903', username: 'hani0903' } });
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : '로그인 중 오류가 발생했습니다.';
+            dispatch({ type: 'AUTH_ERROR', payload: errorMessage });
+            throw error;
+        }
+    }, []);
+
+    const logout = useCallback(async (): Promise<void> => {
+        try {
+            // await authService.logout(); -> 서버에 아직 api 없음
+            dispatch({ type: 'AUTH_LOGOUT' });
+        } catch (error) {
+            console.error('로그아웃 중 오류:', error);
+            // 로그아웃은 실패해도 로컬 상태는 초기화
+            dispatch({ type: 'AUTH_LOGOUT' });
+        }
+    }, []);
+
+    const contextValue: AuthContextValue = {
+        ...state,
+        login,
+        logout,
+    };
+
+    return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
+};
+
+export default AuthProvider;

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import AuthProvider from './AuthProvider';
+
+interface AppProvidersProps {
+    children: React.ReactNode;
+}
+
+export const AppProviders: React.FC<AppProvidersProps> = ({ children }) => {
+    return <AuthProvider>{children}</AuthProvider>;
+};

--- a/src/reducers/AuthReducer.ts
+++ b/src/reducers/AuthReducer.ts
@@ -1,0 +1,61 @@
+import type { AuthState, User } from '../type/auth-types';
+
+type AuthAction =
+    | { type: 'AUTH_START' }
+    | { type: 'AUTH_SUCCESS'; payload: User }
+    | { type: 'AUTH_ERROR'; payload: string }
+    | { type: 'AUTH_LOGOUT' }
+    | { type: 'CLEAR_ERROR' };
+
+const initialState: AuthState = {
+    user: null, // 처음에는 사용자 없음
+    isAuthenticated: false, // 로그인 안됨
+    isLoading: false, // 로딩중 아님
+    error: null, // 에러 없음
+};
+
+const authReducer = (state: AuthState, action: AuthAction): AuthState => {
+    switch (action.type) {
+        case 'AUTH_START':
+            // 로그인 시작할 때
+            return {
+                ...state, // 기존 상태 복사
+                isLoading: true, // 로딩 시작
+                error: null, // 이전 에러 지우기
+            };
+
+        case 'AUTH_SUCCESS':
+            // 로그인 성공했을 때
+            return {
+                ...state,
+                user: action.payload, // 사용자 정보 저장
+                isAuthenticated: true, // 로그인됨 표시
+                isLoading: false, // 로딩 끝
+                error: null, // 에러 없음
+            };
+
+        case 'AUTH_ERROR':
+            // 로그인 실패했을 때
+            return {
+                ...state,
+                user: null, // 사용자 정보 없음
+                isAuthenticated: false, // 로그인 안됨
+                isLoading: false, // 로딩 끝
+                error: action.payload, // 에러 메시지 저장
+            };
+
+        case 'AUTH_LOGOUT':
+            // 로그아웃할 때 - 모든 상태 초기화
+            return initialState;
+
+        case 'CLEAR_ERROR':
+            // 에러만 지우기
+            return { ...state, error: null };
+
+        default:
+            // 알 수 없는 액션이면 기존 상태 그대로
+            return state;
+    }
+};
+
+export default authReducer;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,0 +1,38 @@
+import { createBrowserRouter } from 'react-router-dom';
+import RootPage from '../pages/Root';
+import ErrorPage from '../pages/Error';
+import MainPage from '../pages/MainPage';
+import Greeting from '../pages/Greeting';
+import CreateGroupPage from '../pages/CreateGroupPage';
+import GithubPage from '../pages/GithubPage';
+import GitHubLoginCallback from '../pages/GithubLoginCallback';
+
+export const router = createBrowserRouter([
+    {
+        path: '/',
+        element: <RootPage />,
+        errorElement: <ErrorPage />,
+        children: [
+            {
+                index: true,
+                element: <MainPage />,
+            },
+            {
+                path: 'main',
+                element: <GitHubLoginCallback />,
+            },
+            {
+                path: 'github',
+                element: <GithubPage />,
+            },
+            {
+                path: 'create',
+                element: <CreateGroupPage />,
+            },
+            {
+                path: 'greeting',
+                element: <Greeting />,
+            },
+        ],
+    },
+]);

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,0 +1,78 @@
+// services/auth.service.ts
+import axios from 'axios';
+import type { AuthTokens } from '../type/auth-types';
+
+const API_BASE_URL = 'https://mogaktae.inuappcenter.kr';
+const TOKEN_STORAGE_KEY = 'auth_tokens';
+
+class AuthService {
+    private tokens: AuthTokens | null = null;
+
+    constructor() {
+        this.loadTokensFromStorage();
+        this.setupBasicAxiosInterceptor();
+    }
+
+    // 토큰 저장
+    setTokens(tokens: AuthTokens): void {
+        this.tokens = tokens;
+        localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(tokens));
+    }
+
+    // 토큰 가져오기
+    getTokens(): AuthTokens | null {
+        return this.tokens;
+    }
+
+    // 토큰 존재 여부 확인
+    hasTokens(): boolean {
+        return this.tokens !== null && this.tokens.accessToken !== '';
+    }
+
+    // 토큰 클리어
+    clearTokens(): void {
+        this.tokens = null;
+        localStorage.removeItem(TOKEN_STORAGE_KEY);
+    }
+
+    // 로컬 스토리지에서 토큰 로드
+    private loadTokensFromStorage(): void {
+        try {
+            const storedTokens = localStorage.getItem(TOKEN_STORAGE_KEY);
+            if (storedTokens) {
+                this.tokens = JSON.parse(storedTokens);
+            }
+        } catch (error) {
+            console.error('토큰 로드 실패:', error);
+            this.clearTokens();
+        }
+    }
+
+    // 로그아웃
+    async logout(): Promise<void> {
+        try {
+            if (this.tokens?.refreshToken) {
+                await axios.post(`${API_BASE_URL}/auth/logout`, {
+                    refreshToken: this.tokens.refreshToken,
+                });
+            }
+        } finally {
+            this.clearTokens();
+        }
+    }
+
+    // 기본 인터셉터 설정
+    private setupBasicAxiosInterceptor(): void {
+        axios.interceptors.request.use(
+            (config) => {
+                if (this.tokens?.accessToken && config.url?.startsWith(API_BASE_URL)) {
+                    config.headers.Authorization = `Bearer ${this.tokens.accessToken}`;
+                }
+                return config;
+            },
+            (error) => Promise.reject(error)
+        );
+    }
+}
+
+export const authService = new AuthService();

--- a/src/type/auth-types.ts
+++ b/src/type/auth-types.ts
@@ -1,0 +1,18 @@
+export interface User {
+    id: string;
+    username: string;
+    email?: string; // ? = 선택적 속성
+    avatarUrl?: string;
+}
+
+export interface AuthTokens {
+    accessToken: string; // API 요청할 때 사용하는 토큰
+    refreshToken: string; // accessToken 갱신할 때 사용하는 토큰
+}
+
+export interface AuthState {
+    user: User | null; // 로그인한 사용자 정보 (로그인 안했으면 null)
+    isAuthenticated: boolean; // true = 로그인됨, false = 로그인 안됨
+    isLoading: boolean; // true = 로딩중, false = 로딩완료
+    error: string | null; // 에러 메시지 (에러 없으면 null)
+}


### PR DESCRIPTION
## 연관 이슈

#4 

<br/>

## 📁 작업 내용
- 사용자 인증 서비스 구현
- JWT 토큰 기반 로그인/회원가입/로그아웃 기능 추가
- 라우터 설정을 별도 파일로 분리하여 코드 구조 개선
- 헤더 인증 버튼들에 실제 기능 연결

<br/>

## 🖥 구현 내용
### 인증 플로우
- 로그인 성공 시 JWT 토큰 저장
- 로그아웃 시 토큰 정리
- 새로고침해도 로그인 상태 유지

### 헤더 UI 조건부 렌더링 확인 

> 로그인 상태에 따라 조건부 렌더링이 잘 되는 걸 확인했습니다.

- 로그인 전: 로그인/회원가입 버튼 표시
- 로그인 후: 로그아웃 버튼 표시


<br/>

## ✔ 리뷰 요청 사항

### 1. API URL 관리 방식
현재 각 페이지에 API URL을 하드코딩해둔 상태입니다. 이 부분은 어떻게 관리하는게 좋을까요? 저도 찾아보겠습니다!
<br/>

## 📁 추후 개선 예정
- axios 인터셉터를 활용해서 토큰 자동 주입 로직을 작성해보겠습니다.
- 에러 핸들링 코드를 아직 작성하지 않았는데, 추가하겠습니다.

<br/>
